### PR TITLE
Safer GitHub Actions Workflow for golangci-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
-# safer-golangci-lint
+# Safer GitHub Actions Workflow for golangci-lint
+
 Use golangci-lint more securely in your CI workflow.
+
+## Quick Start
+Copy safer-golangci-lint.yml into [your_github_repo]/.github/workflows/
+
+You should configure your .golangci.yml normally, as instructed in golangci-lint docs.
+
+## Upgrading to newer version of golangci-lint
+1. specify new version number in GOLINTERS_VERSION
+2. specify new hash of tarball in GOLINTERS_TGZ_HASH
+
+## safer-golangci-lint.yml
+
+100% of the script for downloading, installing, and running golangci-lint
+is embedded in the workflow file.  The embedded SHA384 is used to verify the 
+downloaded golangci-lint tarball (e.g. golangci-lint-1.40.1-linux-amd64.tar.gz). 
+
+## Why?
+1. Avoid downloading and executing unverified wrapper scripts or actions each time a workflow runs.  
+   See https://www.securityweek.com/codecov-bash-uploader-dev-tool-compromised-supply-chain-hack
+2. Use openssl instead of sha256sum because it's easier to change hash algo to BLAKE2s, SHA3-256, etc.
+3. Use SHA384 instead of SHA256 to avoid debating strangers about length extension attacks and gzip file format.
+4. Use embedded SHA384 instead of downloading CHECKSUM because CHECKSUM file isn't digitally signed.
+5. Use binary instead of building from source because it's probably easier to detect backdoors in one binary 
+   than all the combined source code of dozens of linters and all their required 3rd-party packages.
+
+## Changelog
+2021-05-16  Created. Use golangci-lint 1.40.1, Go 1.15.x, and ubuntu-latest.  
+ - SHA256 of golangci-lint-1.40.1-linux-amd64.tar.gz is  
+   7c133b4b39c0a46cf8d67265da651f169079d137ae71aee9b5934e2281bd18d3
+ - SHA384 of golangci-lint-1.40.1-linux-amd64.tar.gz) is  
+   d0b9e9c0eac5c5e03b9feb546d181918fca9abc94656824badccacc77aa91bc78ab99fd22094d634d3a58a91353fb1b9
+
+## License
+safer-golangci-lint is licensed under MIT License.  See [LICENSE](LICENSE) for the full license text.  
+https://github.com/x448/safer-golangci-lint
+
+Copyright © 2021 Montgomery Edwards⁴⁴⁸ (github.com/x448).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Use golangci-lint more securely in your CI workflow.
 ## Quick Start
 Copy safer-golangci-lint.yml into [your_github_repo]/.github/workflows/
 
-You should configure your .golangci.yml normally, as instructed in golangci-lint docs.
+Configure your .golangci.yml normally, as instructed in golangci-lint docs.
 
 ## Upgrading to newer version of golangci-lint
 1. specify new version number in GOLINTERS_VERSION

--- a/safer-golangci-lint.yml
+++ b/safer-golangci-lint.yml
@@ -1,0 +1,96 @@
+# Copyright © 2021 Montgomery Edwards⁴⁴⁸ (github.com/x448).
+# This file is licensed under MIT License.
+#
+# Safer GitHub Actions Workflow for golangci-lint.
+# https://github.com/x448/safer-golangci-lint 
+#
+# safer-golangci-lint.yml
+#
+# 100% of the script for downloading, installing, and running golangci-lint
+# is embedded in this file.  The embedded SHA384 is used to verify the 
+# downloaded golangci-lint tarball (golangci-lint-1.40.1-linux-amd64.tar.gz). 
+#
+# Why?
+#   1. Avoid downloading and executing unverified wrapper scripts or actions each time a workflow runs.
+#      See https://www.securityweek.com/codecov-bash-uploader-dev-tool-compromised-supply-chain-hack
+#   2. Use openssl instead of sha256sum because it's easier to change hash algo to BLAKE2s, SHA3-256, etc.
+#   3. Use SHA384 instead of SHA256 to avoid debating strangers about length extension attacks and gzip file format.
+#   4. Use embedded SHA384 instead of downloading CHECKSUM because CHECKSUM file isn't digitally signed.
+#   5. Use binary instead of building from source because it's probably easier to detect backdoors in one binary 
+#      than all the combined source code of dozens of linters and all their required 3rd-party packages.
+#
+# To use:
+# Copy this file into [github_repo]/.github/workflows/
+#
+# Configure [github_repo]/.golangci.yml normally as instructed in golangci-lint docs.
+#
+# To use a newer version of golangci-lint, change these values:
+#   1. GOLINTERS_VERSION
+#   2. GOLINTERS_TGZ_HASH
+#
+# 2021-05-16  Created. Use golangci-lint 1.40.1, Go 1.15.x, and ubuntu-latest.
+#             sha256(tar.gz) is 7c133b4b39c0a46cf8d67265da651f169079d137ae71aee9b5934e2281bd18d3
+#             sha384(tar.gz) is d0b9e9c0eac5c5e03b9feb546d181918fca9abc94656824badccacc77aa91bc78ab99fd22094d634d3a58a91353fb1b9
+
+name: Lint
+
+on:  
+  pull_request:
+    types: [opened, synchronize, closed]
+  push:
+    branches: [main, master]
+
+env:
+  GOLINTERS_VERSION: 1.40.1
+  GOLINTERS_ARCH: linux-amd64
+  GOLINTERS_TGZ_DGST: d0b9e9c0eac5c5e03b9feb546d181918fca9abc94656824badccacc77aa91bc78ab99fd22094d634d3a58a91353fb1b9
+  OPENSSL_DGST_CMD: openssl dgst -sha384 -r
+  CURL_CMD: curl --proto =https --tlsv1.2 --location --silent --show-error --fail
+  
+jobs:
+  main:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+        
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.x
+                      
+      - name: Install golangci-lint
+        run: |
+          GOLINTERS_URL_PREFIX="https://github.com/golangci/golangci-lint/releases/download/v${GOLINTERS_VERSION}/"
+          GOLINTERS_TGZ="golangci-lint-${GOLINTERS_VERSION}-${GOLINTERS_ARCH}.tar.gz"
+          GOLINTERS_EXPECTED_DGST="${GOLINTERS_TGZ_DGST} *${GOLINTERS_TGZ}"
+          DGST_CMD="${OPENSSL_DGST_CMD} ${GOLINTERS_TGZ}"
+
+          cd $(mktemp -d /tmp/golinters.XXXXX)
+          ${CURL_CMD} "${GOLINTERS_URL_PREFIX}${GOLINTERS_TGZ}" --output ${GOLINTERS_TGZ}
+
+          GOLINTERS_GOT_DGST=$(${DGST_CMD})
+          if [ "${GOLINTERS_GOT_DGST}" != "${GOLINTERS_EXPECTED_DGST}" ]
+          then
+            echo "Digest of tarball is not equal to expected digest."
+            echo "Expected digest: " "${GOLINTERS_EXPECTED_DGST}"
+            echo "Got digest:      " "${GOLINTERS_GOT_DGST}"
+            exit 1
+          fi
+
+          tar --no-same-owner -xzf "${GOLINTERS_TGZ}" --strip-components 1
+          install golangci-lint $(go env GOPATH)/bin
+        shell: bash
+          
+      # Run required linters enabled in .golangci.yml     
+      - name: Run required linters in .golangci.yml
+        run: $(go env GOPATH)/bin/golangci-lint run --timeout=4m
+        shell: bash
+        
+      # Run noisy linters as optional (enable them using command line parameters)
+      - name: Run optional linters (not required to pass)
+        run: $(go env GOPATH)/bin/golangci-lint run --timeout=4m --issues-exit-code=0 -E dupl -E gocritic -E gosimple -E lll -E prealloc
+        shell: bash


### PR DESCRIPTION
Use golangci-lint more securely in your CI workflow.

100% of the script for downloading, installing, and running golangci-lint is embedded in the workflow file. The embedded SHA384 is used to verify the downloaded golangci-lint tarball (e.g. golangci-lint-1.40.1-linux-amd64.tar.gz).

1. This avoids downloading and executing unverified wrapper scripts or actions each time a workflow runs.
    See https://www.securityweek.com/codecov-bash-uploader-dev-tool-compromised-supply-chain-hack
2. Use openssl instead of sha256sum because it's easier to change hash algo to BLAKE2s, SHA3-256, etc.
3. Use SHA384 instead of SHA256 to avoid debating strangers about length extension attacks and gzip file format.
4. Use embedded SHA384 instead of downloading CHECKSUM because CHECKSUM file isn't digitally signed.
5. Use binary instead of building from source because it's probably easier to detect backdoors in one binary 
    than all the combined source code of dozens of linters and all their required 3rd-party packages.
