### PR TITLE
Update safer-golangci-lint.yml for 1.52.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ This workflow downloads, verifies, and runs [golangci/golangci-lint](https://git
 ## Why use safer-golangci-lint.yml?
 
 Use this to avoid two problems:
-- Bad practice of using pipe-to-shell, which allows 3rd-party script to execute without your review.
-- More time-consuming practice of reviewing and pinning [golangci-lint-action](https://github.com/golangci/golangci-lint-action), which requires:
+- Bad practice of using curl-to-shell, which allows 3rd-party script to change without notice and execute.
+- More time-consuming practice of reviewing and pinning [golangci-lint-action](https://github.com/golangci/golangci-lint-action) requires:
   - Reviewing each release of golangci-lint-action, which is relatively time-consuming.
   - Pinning each release after reviewing the code.
 
-With safer-gbolangci-lint.yml, you only need to update 2 variables whenever a new golangci-lint is released:
+With safer-gbolangci-lint.yml, you only need to update 2 variables when you want to use a newer golangci-lint:
  - Version number of golangci-lint.  E.g. "1.52.2".
  - SHA-256 digest of golangci-lint-X.XX.X-linux-amd64.tar.gz. E.g. where "X.XX.X" is "1.52.2".
 
@@ -22,6 +22,7 @@ Everything you need to download, verify, and execute a verified file should be s
 
 Projects using safer-golangci-lint.yml:
  - [fxamacker/cbor](https://github.com/fxamacker/cbor)
+ - [fxamacker/circlehash](https://github.com/fxamacker/circlehash)
  - [x448/float16](https://github.com/x448/float16)
 
 ## safer-golangci-lint.yml

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Changes:
    https://github.com/golangci/golangci-lint/releases
 
 SHA-256
-- safer-golangci-lint.yml (v1.52.2): b23f18bcfdd933ecc324e2ad7459670f25d91d4539fbd366a83c7026aeee577c
+- safer-golangci-lint.yml (v1.52.2): 8f50e053d416e7ef2ccec0cf6c20efb6befbf380f735e7157d4d4611db88d95a
 - golangci-lint-1.52.2-linux-amd64.tar.gz: c9cf72d12058a131746edd409ed94ccd578fbd178899d1ed41ceae3ce5f54501  
   This SHA-256 digest matches golangci-lint-1.52.2-checksums.txt at  
   https://github.com/golangci/golangci-lint/releases

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ This workflow downloads, verifies, and runs [golangci/golangci-lint](https://git
 
 ## Why use safer-golangci-lint.yml?
 
+Use this to avoid two problems:
+- Bad practice of using pipe-to-shell, which allows 3rd-party script to execute without your review.
+- Tedious practice of reviewing and using [golangci-lint-action](https://github.com/golangci/golangci-lint-action), which requires:
+  - Reviewing each release of golangci-lint-action, which is relatively time-consuming.
+  - Pinning each release after reviewing the code.
+
+With safer-gbolangci-lint.yml, just review the self-contained yml file once.  After that, you only need to update 2 variables whenever a new golangci-lint is released:
+ - Version number of golangci-lint.  E.g. "1.52.2".
+ - SHA-256 digest of golangci-lint-X.XX.X-linux-amd64.tar.gz. E.g. where "X.XX.X" is "1.52.2".
+
 What you download and execute shouldn't be able to change at anytime without your review. Linting the same source code should produce deterministic results unless you choose to modify the workflow or linter settings.
 
 Directly executing the output of curl, etc. without verifying the integrity of the downloaded script is risky.  The [Codecov bash script incident](https://www.securityweek.com/codecov-bash-uploader-dev-tool-compromised-supply-chain-hack) is an example of what can happen.
@@ -42,18 +52,28 @@ Or if you don't want to wait for an update, you can:
 1. specify new version number in GOLINTERS_VERSION
 2. specify new hash of tarball in GOLINTERS_TGZ_HASH
 
-## Release v1.51.2
+## Release v1.52.2
 
 Changes:
-  - Bump golangci-lint to 1.51.2
+ - Bump Go to 1.20
+ - Bump actions/setup-go to v4
+ - Use defaults for pull_request trigger
+ - Bump golangci-lint to 1.52.2
+ - Hash of golangci-lint-1.52.2-linux-amd64.tar.gz
+   SHA-256: c9cf72d12058a131746edd409ed94ccd578fbd178899d1ed41ceae3ce5f54501
+   This SHA-256 digest matches golangci-lint-1.52.2-checksums.txt at
+   https://github.com/golangci/golangci-lint/releases
 
 SHA-256
-- golangci-lint-1.51.2-linux-amd64.tar.gz: 4de479eb9d9bc29da51aec1834e7c255b333723d38dbd56781c68e5dddc6a90b
-- safer-golangci-lint.yml (v1.51.2): 787888454d6b324aa9734c7afa1165eed99bb580a518b262ed68efcab9e544b4
+- safer-golangci-lint.yml (v1.51.2): b23f18bcfdd933ecc324e2ad7459670f25d91d4539fbd366a83c7026aeee577c
+- golangci-lint-1.52.2-linux-amd64.tar.gz: c9cf72d12058a131746edd409ed94ccd578fbd178899d1ed41ceae3ce5f54501
+  This SHA-256 digest matches golangci-lint-1.52.2-checksums.txt at
+  https://github.com/golangci/golangci-lint/releases
+
 
 ## License
 
 safer-golangci-lint is licensed under MIT License.  See [LICENSE](LICENSE) for the full license text.  
 https://github.com/x448/safer-golangci-lint
 
-Copyright © 2021 Montgomery Edwards⁴⁴⁸ (github.com/x448).
+Copyright © 2021-2023 Montgomery Edwards⁴⁴⁸ (github.com/x448).

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ This workflow downloads, verifies, and runs [golangci/golangci-lint](https://git
 
 Use this to avoid two problems:
 - Bad practice of using pipe-to-shell, which allows 3rd-party script to execute without your review.
-- Tedious practice of reviewing and using [golangci-lint-action](https://github.com/golangci/golangci-lint-action), which requires:
+- More time-consuming practice of reviewing and pinning [golangci-lint-action](https://github.com/golangci/golangci-lint-action), which requires:
   - Reviewing each release of golangci-lint-action, which is relatively time-consuming.
   - Pinning each release after reviewing the code.
 
-With safer-gbolangci-lint.yml, just review the self-contained yml file once.  After that, you only need to update 2 variables whenever a new golangci-lint is released:
+With safer-gbolangci-lint.yml, you only need to update 2 variables whenever a new golangci-lint is released:
  - Version number of golangci-lint.  E.g. "1.52.2".
  - SHA-256 digest of golangci-lint-X.XX.X-linux-amd64.tar.gz. E.g. where "X.XX.X" is "1.52.2".
 
@@ -60,14 +60,14 @@ Changes:
  - Use defaults for pull_request trigger
  - Bump golangci-lint to 1.52.2
  - Hash of golangci-lint-1.52.2-linux-amd64.tar.gz
-   SHA-256: c9cf72d12058a131746edd409ed94ccd578fbd178899d1ed41ceae3ce5f54501
-   This SHA-256 digest matches golangci-lint-1.52.2-checksums.txt at
+   SHA-256: c9cf72d12058a131746edd409ed94ccd578fbd178899d1ed41ceae3ce5f54501  
+   This SHA-256 digest matches golangci-lint-1.52.2-checksums.txt at  
    https://github.com/golangci/golangci-lint/releases
 
 SHA-256
-- safer-golangci-lint.yml (v1.51.2): b23f18bcfdd933ecc324e2ad7459670f25d91d4539fbd366a83c7026aeee577c
-- golangci-lint-1.52.2-linux-amd64.tar.gz: c9cf72d12058a131746edd409ed94ccd578fbd178899d1ed41ceae3ce5f54501
-  This SHA-256 digest matches golangci-lint-1.52.2-checksums.txt at
+- safer-golangci-lint.yml (v1.52.2): b23f18bcfdd933ecc324e2ad7459670f25d91d4539fbd366a83c7026aeee577c
+- golangci-lint-1.52.2-linux-amd64.tar.gz: c9cf72d12058a131746edd409ed94ccd578fbd178899d1ed41ceae3ce5f54501  
+  This SHA-256 digest matches golangci-lint-1.52.2-checksums.txt at  
   https://github.com/golangci/golangci-lint/releases
 
 

--- a/safer-golangci-lint.yml
+++ b/safer-golangci-lint.yml
@@ -29,7 +29,7 @@
 #
 # Release v1.52.2 (May 14, 2023)
 #   - Bump Go to 1.20
-#   - Bummp actions/setup-go to v4
+#   - Bump actions/setup-go to v4
 #   - Bump golangci-lint to 1.52.2
 #   - Hash of golangci-lint-1.52.2-linux-amd64.tar.gz
 #     - SHA-256: c9cf72d12058a131746edd409ed94ccd578fbd178899d1ed41ceae3ce5f54501

--- a/safer-golangci-lint.yml
+++ b/safer-golangci-lint.yml
@@ -1,4 +1,4 @@
-# Copyright © 2021 Montgomery Edwards⁴⁴⁸ (github.com/x448).
+# Copyright © 2021-2023 Montgomery Edwards⁴⁴⁸ (github.com/x448).
 # This file is licensed under MIT License.
 #
 # Safer GitHub Actions Workflow for golangci-lint.
@@ -27,11 +27,13 @@
 #   1. GOLINTERS_VERSION
 #   2. GOLINTERS_TGZ_DGST
 #
-# Release v1.51.2 (February 19, 2023)
-#   - Bump golangci-lint to 1.51.2
-#   - Hash of golangci-lint-1.51.2-linux-amd64.tar.gz
-#     - SHA-256: 4de479eb9d9bc29da51aec1834e7c255b333723d38dbd56781c68e5dddc6a90b
-#                This SHA-256 digest matches golangci-lint-1.51.2-checksums.txt at
+# Release v1.52.2 (May 14, 2023)
+#   - Bump Go to 1.20
+#   - Bummp actions/setup-go to v4
+#   - Bump golangci-lint to 1.52.2
+#   - Hash of golangci-lint-1.52.2-linux-amd64.tar.gz
+#     - SHA-256: c9cf72d12058a131746edd409ed94ccd578fbd178899d1ed41ceae3ce5f54501
+#                This SHA-256 digest matches golangci-lint-1.52.2-checksums.txt at
 #                https://github.com/golangci/golangci-lint/releases
 #
 name: linters
@@ -42,15 +44,14 @@ permissions: {}
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, synchronize, closed]
   push:
     branches: [main, master]
 
 env:
-  GO_VERSION: 1.19
-  GOLINTERS_VERSION: 1.51.2
+  GO_VERSION: 1.20
+  GOLINTERS_VERSION: 1.52.2
   GOLINTERS_ARCH: linux-amd64
-  GOLINTERS_TGZ_DGST: 4de479eb9d9bc29da51aec1834e7c255b333723d38dbd56781c68e5dddc6a90b
+  GOLINTERS_TGZ_DGST: c9cf72d12058a131746edd409ed94ccd578fbd178899d1ed41ceae3ce5f54501
   GOLINTERS_TIMEOUT: 15m
   OPENSSL_DGST_CMD: openssl dgst -sha256 -r
   CURL_CMD: curl --proto =https --tlsv1.2 --location --silent --show-error --fail
@@ -68,7 +69,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true

--- a/safer-golangci-lint.yml
+++ b/safer-golangci-lint.yml
@@ -48,7 +48,7 @@ on:
     branches: [main, master]
 
 env:
-  GO_VERSION: 1.20
+  GO_VERSION: '1.20'
   GOLINTERS_VERSION: 1.52.2
   GOLINTERS_ARCH: linux-amd64
   GOLINTERS_TGZ_DGST: c9cf72d12058a131746edd409ed94ccd578fbd178899d1ed41ceae3ce5f54501


### PR DESCRIPTION
Release v1.52.2 (May 14, 2023)
 - Bump Go to 1.20
 - Bump actions/setup-go to v4
 - Bump golangci-lint to 1.52.2
 - Hash of golangci-lint-1.52.2-linux-amd64.tar.gz
   SHA-256: c9cf72d12058a131746edd409ed94ccd578fbd178899d1ed41ceae3ce5f54501
   This SHA-256 digest matches golangci-lint-1.52.2-checksums.txt at
   https://github.com/golangci/golangci-lint/releases